### PR TITLE
--no-ri --no-rdoc is deprecated, use --no-document

### DIFF
--- a/gem/gemrc
+++ b/gem/gemrc
@@ -1,2 +1,2 @@
-install: --no-rdoc --no-ri
-update: --no-rdoc --no-ri
+install: --no-document
+update: --no--document


### PR DESCRIPTION
--no-ri --no-rdoc is deprecated, use --no-document
Reference: http://guides.rubygems.org/command-reference/
