### PR TITLE
Add no-op and separator to prompt.

### DIFF
--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -3,9 +3,9 @@ function virtualenv_info {
 }
 
 function prompt_char {
-    git branch >/dev/null 2>/dev/null && echo '±' && return
-    hg root >/dev/null 2>/dev/null && echo '☿' && return
-    echo '○'
+    git branch >/dev/null 2>/dev/null && echo  $fg[black]':'$fg[default]'±'$fg[black]';'$fg[default] && return
+    hg root >/dev/null 2>/dev/null && echo $fg[black]':'$fg[default]'☿'$fg[black]';'$fg[default] && return
+    echo $fg[black]':'$fg[default]'○'$fg[black]';'$fg[default]
 }
 
 function box_name {


### PR DESCRIPTION
Add no-op character (:) and separator (;) to all three prompt character
variants. This allows triple-clicking to copy entire command line and pasting
without the prompt character interfering.