### PR TITLE
Crated Linux version of tmux.conf

### DIFF
--- a/tmux/tmux.linux
+++ b/tmux/tmux.linux
@@ -1,0 +1,156 @@
+# use UTF8
+set -g utf8
+set-window-option -g utf8 on
+
+# make tmux display things in 256 colors
+# set -g default-terminal "screen-256color"
+set -g default-terminal "xterm-256color"
+
+# set scrollback history to 30000 (30k)
+set -g history-limit 30000
+
+# set ` (tic) as the default prefix key combination
+# and unbind C-b to free it up
+unbind C-b
+set -g prefix `
+
+# use send-prefix to pass ` (tic) through to application
+bind ` send-prefix
+
+# shorten command delay
+set -sg escape-time 1
+
+# set window and pane index to 1 (0 by default)
+set-option -g base-index 1
+setw -g pane-base-index 1
+
+# reload ~/.tmux.conf using PREFIX r
+bind r source-file ~/.tmux.conf \; display "Reloaded!"
+
+# use PREFIX | to split window horizontally and PREFIX - to split vertically
+bind | split-window -h
+bind - split-window -v
+
+# Make the current window the first window
+bind T swap-window -t 1
+
+# map Vi movement keys as pane movement keys
+bind h select-pane -L
+bind j select-pane -D
+bind k select-pane -U
+bind l select-pane -R
+
+# and use C-h and C-l to cycle thru panes
+bind -r C-h select-window -t :-
+bind -r C-l select-window -t :+
+
+# resize panes using PREFIX H, J, K, L
+bind H resize-pane -L 5
+bind J resize-pane -D 5
+bind K resize-pane -U 5
+bind L resize-pane -R 5
+
+# C-i for even-vertical arrangement and C-o to zoom current pane
+bind-key C-i select-layout even-vertical
+bind-key C-v select-layout even-horizontal
+bind-key C-o resize-pane -y 1000
+
+# Sync panes
+bind C-s set-window-option synchronize-panes
+
+# explicitly disable mouse control
+# setw -g mode-mouse off
+# set -g mouse-select-pane off
+# set -g mouse-resize-pane off
+# set -g mouse-select-window off
+
+# mouse control for tmux v2.1
+# set -g mouse off
+
+# ---------------------
+# Copy & Paste
+# ---------------------
+# provide access to the clipboard for pbpaste, pbcopy
+# set -g default-command "reattach-to-user-namespace -l $SHELL; cd ."
+# set-option -g default-command "reattach-to-user-namespace -l zsh"
+# set-window-option -g automatic-rename on
+
+# use vim keybindings in copy mode
+# setw -g mode-keys vi
+
+# setup 'v' to begin selection as in Vim
+# bind-key -t vi-copy v begin-selection
+# bind-key -t vi-copy y copy-pipe "reattach-to-user-namespace pbcopy"
+
+# update default binding of 'Enter' to also use copy-pipe
+# unbind -t vi-copy Enter
+# bind-key -t vi-copy Enter copy-pipe "reattach-to-user-namespace pbcopy"
+
+# bind y run 'tmux save-buffer - | reattach-to-user-namespace pbcopy '
+# bind C-y run 'tmux save-buffer - | reattach-to-user-namespace pbcopy '
+
+# Save entire tmux history to a file - file will be on machine where tmux is
+# running
+# bind-key * command-prompt -p 'save history to filename:' -I '~/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
+
+# -----------------------
+# Multistart panes
+# ----------------------
+bind-key P run-shell 'tmux-multistart as'
+bind-key A run-shell 'tmux-multistart alpha'
+bind-key B run-shell 'tmux-multistart beta'
+bind-key W run-shell 'tmux-multistart web'
+bind-key D run-shell 'tmux-multistart dev'
+bind-key T run-shell 'tmux-multistart txhub'
+
+bind-key C command-prompt -p "machine(s)/group: " "run-shell 'tmux-multistart %1'"
+
+# ----------------------
+# set some pretty colors
+# ----------------------
+# set pane colors - hilight the active pane
+set-option -g pane-border-fg colour235 #base02
+set-option -g pane-active-border-fg colour33 #blue
+#set-option -g pane-active-border-fg colour240 #base01
+
+# colorize messages in the command line
+set-option -g message-bg black #base02
+set-option -g message-fg brightred #orange
+
+# ----------------------
+# Status Bar
+# -----------------------
+set-option -g status on                # turn the status bar on
+set -g status-utf8 on                  # set utf-8 for the status bar
+set -g status-interval 5               # set update frequencey (default 15 seconds)
+set -g status-justify centre           # center window list for clarity
+# set-option -g status-position top    # position the status bar at top of screen
+
+# visual notification of activity in other windows
+setw -g monitor-activity on
+set -g visual-activity on
+
+# set color for status bar
+set-option -g status-bg colour235 #base02
+set-option -g status-fg yellow #yellow
+set-option -g status-attr dim 
+
+# set window list colors - red for active and cyan for inactive
+set-window-option -g window-status-fg brightblue #base0
+set-window-option -g window-status-bg colour236 
+set-window-option -g window-status-attr dim
+
+set-window-option -g window-status-current-fg brightred #orange
+set-window-option -g window-status-current-bg colour236 
+set-window-option -g window-status-current-attr bright
+
+# show host name and IP address on left side of status bar
+set -g status-left-length 85 
+#set -g status-left "#[fg=green]: #h : #[fg=brightblue]#(dig +short myip.opendns.com @resolver1.opendns.com) #[fg=yellow]#(ifconfig en0 | grep 'inet ' | awk '{print \"en0 \" $2}') #(ifconfig en1 | grep 'inet ' | awk '{print \"en1 \" $2}') #(ifconfig en3 | grep 'inet ' | awk '{print \"en3 \" $2}') #[fg=red]#(ifconfig tun0 | grep 'inet ' | awk '{print \"vpn \" $2}') #[fg=green]#(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk -F': ' '/ SSID/{print $2}') "
+set -g status-left "#[fg=green]: #h : #[fg=brightblue]#(curl icanhazip.com) #[fg=yellow]#(ifconfig en0 | grep 'inet ' | awk '{print \"en0 \" $2}') #(ifconfig en1 | grep 'inet ' | awk '{print \"en1 \" $2}') #(ifconfig en3 | grep 'inet ' | awk '{print \"en3 \" $2}') #[fg=red]#(ifconfig tun0 | grep 'inet ' | awk '{print \"vpn \" $2}') #[fg=green]#(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk -F': ' '/ SSID/{print $2}') "
+
+# show session name, window & pane number, date and time on right side of
+# status bar
+set -g status-right-length 80
+set -g status-right "#[fg=cyan]#{=15:pane_title} : #[fg=blue]#S #I:#P #[fg=yellow]: %d %b %Y #[fg=green]: %l:%M %p : #(date -u | awk '{print $4}') :"
+


### PR DESCRIPTION
OS X requires the reattach-to-user-namespace setup for copy/paste to work properly.
Removed those lines and created tmux.linux copy of configuration for use on
Linux OSes.