### PR TITLE
force tmux colors when attaching to session

### DIFF
--- a/scripts/blog
+++ b/scripts/blog
@@ -9,7 +9,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s blog -n home -d
+tmux new-session -s blog -n home -d
 
 # set default directory
 tmux send-keys -t blog:1 'cd ~/' C-m
@@ -57,4 +57,4 @@ tmux send-keys -t blog:5.3 'rake watch[drafts]' C-m
 
  # end if statement and attach mytmux if it existed
 fi
-tmux attach -t blog
+tmux -2 attach -t blog

--- a/scripts/chef
+++ b/scripts/chef
@@ -9,7 +9,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s chef -n vpn -d
+tmux new-session -s chef -n vpn -d
 
 # set default directory
 tmux send-keys -t chef:1 'cd ~/' C-m
@@ -53,4 +53,4 @@ tmux send-keys -t chef:4 'ls' C-m
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t chef
+tmux -2 attach -t chef

--- a/scripts/console
+++ b/scripts/console
@@ -10,7 +10,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s console -n desktop -d
+tmux new-session -s console -n desktop -d
 
 # set default directory
 tmux send-keys -t console:1 'cd ~/' C-m
@@ -67,4 +67,4 @@ tmux set-window-option synchronize-panes
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t console
+tmux -2 attach -t console

--- a/scripts/dementia
+++ b/scripts/dementia
@@ -9,7 +9,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s dementia -n desktop -d
+tmux new-session -s dementia -n desktop -d
 
 # set default directory
 tmux send-keys -t dementia:1 'cd ~/' C-m
@@ -42,4 +42,4 @@ tmux send-keys -t dementia:3.2 'ls -al' C-m
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t dementia
+tmux -2 attach -t dementia

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -10,7 +10,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s deploy -n desktop -d
+tmux new-session -s deploy -n desktop -d
 
 # set default directory
 tmux send-keys -t deploy:1 'cd ~/' C-m
@@ -67,4 +67,4 @@ tmux set-window-option synchronize-panes
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t deploy
+tmux -2 attach -t deploy

--- a/scripts/logs
+++ b/scripts/logs
@@ -10,7 +10,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s logs -n desktop -d
+tmux new-session -s logs -n desktop -d
 
 # set default directory
 tmux send-keys -t logs:1 'cd ~/' C-m
@@ -67,4 +67,4 @@ tmux set-window-option synchronize-panes
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t logs
+tmux -2 attach -t logs

--- a/scripts/tools
+++ b/scripts/tools
@@ -10,7 +10,7 @@ if [ $? != 0 ]
 then
 
 # if session does not exist create it
-tmux -2 new-session -s tools -n desktop -d
+tmux new-session -s tools -n desktop -d
 
 # set default directory
 tmux send-keys -t tools:1 'cd ~/' C-m
@@ -34,4 +34,4 @@ tmux send-keys -t tools:4 'ssh trebor' C-m
 
 # end if statement and attach mytmux if it existed
 fi
-tmux attach -t tools
+tmux -2 attach -t tools


### PR DESCRIPTION
The -2 option forces tmux to assume the terminal supports 256 colours.
When attaching to a session we should force tmux to support 256
colors and not when creating a new session.