### PR TITLE
Simplifying GPG setup

### DIFF
--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -146,7 +146,7 @@ alias tmux='tmux -2'
 # }}}
 # Mutt {{{
 # alias mutt='cd ~/Desktop && mutt'
-alias mutt='mutt -e "set crypt_use_gpgme=no"'
+# alias mutt='mutt -e "set crypt_use_gpgme=no"'
 
 # }}}
 # Vagrant {{{

--- a/bash/bash_aliases
+++ b/bash/bash_aliases
@@ -145,7 +145,7 @@ alias tmux='tmux -2'
 
 # }}}
 # Mutt {{{
-# alias mutt='cd ~/Desktop && mutt'
+alias mutt='cd ~/Desktop && mutt && cd -'
 # alias mutt='mutt -e "set crypt_use_gpgme=no"'
 
 # }}}

--- a/mutt/accounts/codeprole.muttrc
+++ b/mutt/accounts/codeprole.muttrc
@@ -3,43 +3,20 @@ my_hdr From: code.prole@gmail.com (code prole)
 my_hdr Reply-To: code.prole@gmail.com (code prole)
 my_hdr Errors-To: code.prole@gmail.com
 my_hdr Organization:
+my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
+my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-# set imap_user            = 'code.prole@gmail.com'
-# source "gpg -d -q $HOME/.mutt/passwords/codeprole.gpg |"
-# set realname             = 'Mark Nichols'
-# set folder               = "imaps://imap.gmail.com:993"
-# set smtp_url             = "smtp://code.prole@smtp.gmail.com:587"
-
+# Mailboxes
 set hostname             = ""
 set folder               = "~/.mail/codeprole/"
+set from                 = 'code.prole@gmail.com'
 set sendmail             = "/usr/bin/msmtp -a codeprole"
 
-set from                 = 'code.prole@gmail.com'
 set spoolfile            = "+INBOX"
 set postponed            = "+Drafts"
 set record               = '+Sent'
 
-# unmailboxes *
-# mailboxes "+Inbox" "+[Gmail]/All Mail" "+[Gmail]/Drafts" "+[Gmail]/Sent\ Mail"
-# mailboxes "+Inbox" "+Drafts" "+Sent" "+Trash" "+Archive"
-# mailboxes `find ~/.mail/codeprole/ -type d -name cur -printf '%h\t%d\n'| sort -n | tr ' ' '\\ ' | awk -F'\t' '{ ORS=" "}{ print $1 }'`
-
+# Set my_acct and format status bar
 set my_acct              = 'code prole'
 set status_format=" $my_acct : %m messages, %n unread  %> (%P) [%l] (%v) "
-#######################################################
-###  Account specific GPG
-#######################################################
-my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
-my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-send-hook code.prole@gmial.com 'set pgp_autosign; set pgp_autoencrypt'
-pgp-hook code.prole@gmail.com 53445200
-#
-set pgp_encrypt_only_command="/usr/lib/mutt/pgpewrap gpg --batch --quiet --no-verbose --output - --encrypt --textmode --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_encrypt_sign_command="/usr/lib/mutt/pgpewrap gpg --passphrase-fd 0 --batch --quiet --no-verbose --textmode --output - --encrypt --sign %?a?-u %a? --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_sign_as=53445200
-#
-#######################################################
-###  GPG Common
-#######################################################
-# source ~/.mutt/accounts/gpgcommon.confg

--- a/mutt/accounts/mark.muttrc
+++ b/mutt/accounts/mark.muttrc
@@ -3,13 +3,10 @@ my_hdr From: mark@zanshin.net (mark nichols)
 my_hdr Reply-To: mark@zanshin.net (mark nichols)
 my_hdr Errors-To: mark@zanshin.net
 my_hdr Organization:
+my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
+my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-# set imap_user            = 'mark_zanshin'
-# source 'gpg -d -q $HOME/.mutt/passwords/mark.gpg |'
-# set realname             = 'Mark Nichols'
-# set folder               = "imaps://mail.webfaction.com:993"
-# set smtp_url             = "smtp://mark_zanshin@smtp.webfaction.com:587"
-
+# Mailboxes
 set hostname             = ""
 set folder               = "~/.mail/mark"
 set from                 = 'mark@zanshin.net'
@@ -20,26 +17,7 @@ set spoolfile            = +"INBOX"
 set postponed            = +"Drafts"
 set record               = +"Sent"
 
-# unmailboxes *
-# mailboxes "+Inbox" "+Archive" "+Drafts" "+Sent" "+Junk"
-# mailboxes `find ~/.mail/mark/ -type d -name cur -printf '%h\t%d\n'| sort -n | tr ' ' '\\ ' | awk -F'\t' '{ ORS=" "}{ print $1 }'`
-
+# Set my_acct and create status bar
 set my_acct              = 'mark'
 set status_format=" $my_acct : %m messages, %n unread  %> (%P) [%l] (%v) "
-#######################################################
-###  Account specific GPG
-#######################################################
-my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
-my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-send-hook mark@zanshin.net 'set pgp_autosign; set pgp_autoencrypt'
-pgp-hook mark@zanshin.net 53445200
-
-set pgp_encrypt_only_command="/usr/lib/mutt/pgpewrap gpg --batch --quiet --no-verbose --output - --encrypt --textmode --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_encrypt_sign_command="/usr/lib/mutt/pgpewrap gpg --passphrase-fd 0 --batch --quiet --no-verbose --textmode --output - --encrypt --sign %?a?-u %a? --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_sign_as=53445200
-
-#######################################################
-###  GPG Common
-#######################################################
-# source ~/.mutt/accounts/gpgcommon.muttrc

--- a/mutt/accounts/marknichols.muttrc
+++ b/mutt/accounts/marknichols.muttrc
@@ -3,44 +3,20 @@ my_hdr From: mark.nichols@gmail.com (mark nichols)
 my_hdr Reply-To: mark.nichols@gmail.com (mark nichols)
 my_hdr Errors-To: mark.nichols@gmail.com
 my_hdr Organization:
+my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
+my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-# set imap_user            = 'mark.nichols@gmail.com'
-# source "gpg -d -q $HOME/.mutt/passwords/marknichols.gpg |"
-# set realname             = 'Mark Nichols'
-# set folder               = "imaps://imap.gmail.com:993"
-# set smtp_url             = "smtp://mark.nichols@smtp.gmail.com:587"
-
+# Mailboxes
 set hostname             = ""
 set folder               = "~/.mail/marknichols/"
+set from                 = 'mark.nichols@gmail.com'
 set sendmail             = "/usr/bin/msmtp -a marknichols"
 
-set from                 = 'mark.nichols@gmail.com'
 set spoolfile            = "+INBOX"
 set postponed            = "+Drafts"
 set record               = '+Sent'
 
-# unmailboxes *
-# mailboxes "+Inbox" "+[Gmail]/All Mail" "+[Gmail]/Drafts" "+[Gmail]/Sent\ Mail"
-# mailboxes "+Inbox" "+Drafts" "+Sent" "+Trash" "+Archive"
-# mailboxes `find ~/.mail/marknichols/ -type d -name cur -printf '%h\t%d\n'| sort -n | tr ' ' '\\ ' | awk -F'\t' '{ ORS=" "}{ print $1 }'`
-
+# Set my_acct and format status bar
 set my_acct              = 'mark nichols'
 set status_format=" $my_acct : %m messages, %n unread  %> (%P) [%l] (%v) "
-#######################################################
-###  Account specific GPG
-#######################################################
-my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
-my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
-#
-# send-hook mark.nichols@gmial.com 'set pgp_autosign; set pgp_autoencrypt'
-send-hook mark.nichols@gmial.com 'set pgp_autosign'
-pgp-hook mark.nichols@gmail.com 53445200
-#
-set pgp_encrypt_only_command="/usr/lb/mutt/pgpewrap gpg --batch --quiet --no-verbose --output - --encrypt --textmode --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_encrypt_sign_command="/usr/lib/mutt/pgpewrap gpg --passphrase-fd 0 --batch --quiet --no-verbose --textmode --output - --encrypt --sign %?a?-u %a? --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_sign_as=53445200
 
-#######################################################
-###  GPG Common
-#######################################################
-# source ~/.mutt/accounts/gpgcommon.confg

--- a/mutt/accounts/root.muttrc
+++ b/mutt/accounts/root.muttrc
@@ -3,42 +3,20 @@ my_hdr From: root@zanshin.net (mark nichols)
 my_hdr Reply-To: root@zanshin.net (mark nichols)
 my_hdr Errors-To: root@zanshin.net
 my_hdr Organization:
+my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
+my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-# set imap_user            = 'root_zanshin'
-# source "gpg -d -q $HOME/.mutt/passwords/root.gpg |"
-# set realname             = 'Mark Nichols'
-# set folder               = "imaps://mail.webfaction.com:993"
-# set smtp_url             = "smtp://root_zanshin@smtp.webfaction.com:587"
-
+# Mailboxes
 set hostname             = ""
 set folder               = "~/.mail/root"
+set from                 = 'root@zanshin.net'
 set sendmail             = "/usr/bin/msmtp -a root"
 
-set from                 = 'root@zanshin.net'
 set spoolfile            = "+INBOX"
 set postponed            = "+Drafts"
 set record               = '+Sent'
 
-# unmailboxes *
-# mailboxes "+Inbox" "+Archive" "+Drafts" "+Sent" "+Junk"
-# mailboxes `find ~/.mail/root/ -type d -name cur -printf '%h\t%d\n'| sort -n | tr ' ' '\\ ' | awk -F'\t' '{ ORS=" "}{ print $1 }'`
-
+# Set my_acct and format status bar
 set my_acct              = 'root'
 set status_format=" $my_acct : %m messages, %n unread  %> (%P) [%l] (%v) "
-#######################################################
-###  Account specific GPG
-#######################################################
-my_hdr X-GPG-Key-Server: hkps://hkps.pool.sks-keyservers.net
-my_hdr X-GPG-Key-FingerPrint: 297F 5FD4 0275 D2E5 48E9  F834 6CCF 1568 5344 5200
 
-send-hook root@zanshin.net 'set pgp_autosign; set pgp_autoencrypt'
-pgp-hook root@zanshin.net 53445200
-
-set pgp_encrypt_only_command="/usr/lib/mutt/pgpewrap gpg --batch --quiet --no-verbose --output - --encrypt --textmode --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_encrypt_sign_command="/usr/lib/mutt/pgpewrap gpg --passphrase-fd 0 --batch --quiet --no-verbose --textmode --output - --encrypt --sign %?a?-u %a? --armor --always-trust --encrypt-to 53445200 -- -r %r -- %f"
-set pgp_sign_as=53445200
-
-#######################################################
-###  GPG Common
-#######################################################
-# source ~/.mutt/accounts/gpgcommon.confg

--- a/mutt/muttrc
+++ b/mutt/muttrc
@@ -118,9 +118,37 @@ macro index \e4 '<sync-mailbox><enter-command>source ~/.mutt/accounts/codeprole.
 
 # }}}
 # GPG {{{
-source ~/.mutt/accounts/gpgcommon.muttrc
-source ~/.mutt/gpg.rc
+# source ~/.mutt/accounts/gpgcommon.muttrc
+# source ~/.mutt/gpg.rc
 # source ~/.gnupg/gpg.conf
+
+# Use GPGME
+set crypt_use_gpgme = yes
+
+# Sign replies to signed emails
+set crypt_replysign = yes
+
+# Encrypt replies to encrypted emails
+set crypt_replyencrypt = yes
+
+# Encrypt and sign replies to encrypted and signed email
+set crypt_replysignencrypted = yes
+
+# Attempt to verify signatures automatically
+set crypt_verify_sig = yes
+
+# Use my key for signing and encrypting
+set pgp_sign_as = 0x53445200
+
+# Automatically sign all out-going email
+set crypt_autosign = yes
+
+# GPG colors
+color body cyan default   "^gpg: Signature made.*"
+color body green default  "^gpg: Good signature from.*"
+color body yellow default "^gpg: Can't check signature.*"
+color body yellow default "^gpg: WARNING: .*"
+color body red default    "^gpg: BAD signature from.*"
 
 # }}}
 # Sidebar navigation {{{

--- a/mutt/muttrc
+++ b/mutt/muttrc
@@ -118,10 +118,6 @@ macro index \e4 '<sync-mailbox><enter-command>source ~/.mutt/accounts/codeprole.
 
 # }}}
 # GPG {{{
-# source ~/.mutt/accounts/gpgcommon.muttrc
-# source ~/.mutt/gpg.rc
-# source ~/.gnupg/gpg.conf
-
 # Use GPGME
 set crypt_use_gpgme = yes
 
@@ -149,6 +145,16 @@ color body green default  "^gpg: Good signature from.*"
 color body yellow default "^gpg: Can't check signature.*"
 color body yellow default "^gpg: WARNING: .*"
 color body red default    "^gpg: BAD signature from.*"
+
+# Switching to GPGME and/or its supporting library
+# changed the prefixes for these strings
+color body cyan default   "^Signature made.*"
+color body green default  "^Good signature from.*"
+color body green default  "^Good signature from.*"
+color body yellow default "^Can't check signature.*"
+color body yellow default "^WARNING: .*"
+color body red default    "^BAD signature from.*"
+
 
 # }}}
 # Sidebar navigation {{{

--- a/mutt/muttrc
+++ b/mutt/muttrc
@@ -204,10 +204,6 @@ bind index gg       first-entry
 bind index G        last-entry
 bind index <space>  collapse-thread
 
-# Postpone message
-bind compose p postpone-message
-bind index p recall-message
-
 # Bounce message functionality
 bind index B bounce-message     # remap bounce message functionality
 
@@ -258,8 +254,8 @@ set editor="nvim '+/^$' -c 'set nohlsearch' -c 'set ft=mail'"
 # set editor = "vim -c 'set spell spelllang=en' -c 'setlocal fo+=aw' +:silent+?^$"
 
 # Postpone message
-bind compose p postpone-message
-bind index p recall-message
+bind compose P postpone-message
+bind index P recall-message
 
 # }}}
 # Macros {{{


### PR DESCRIPTION
Changed setup to use GPGME library, which is built in to Neomutt, and
which provides a far cleaner interface for all things GPG related from
mutt's perspective.
Removed bash mutt alias as we no longer need to to avoid gpgme warning