### PR TITLE
tmux configuration refactoring

### DIFF
--- a/tmux/tmux-macos.conf
+++ b/tmux/tmux-macos.conf
@@ -1,0 +1,3 @@
+# Mac OS X fix for pbcopy, pbpaste and launchctl
+set -g default-command "reattach-to-user-namespace -l ${SHELL}"
+bind-key -T copy-mode-vi 'y' send-keys -X copy-pipe-and-cancel 'reattach-to-user-namespace pbcopy'

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -1,10 +1,6 @@
-# use UTF8
-#set -g utf8
-#set-window-option -g utf8 on
-
 # make tmux display things in 256 colors
 set -g default-terminal "screen-256color"
-# set -g default-terminal "xterm-256color"
+set -g default-shell $SHELL
 
 # set scrollback history to 30000 (30k)
 set -g history-limit 30000
@@ -59,52 +55,26 @@ bind-key C-o resize-pane -y 1000
 # Sync panes
 bind C-s set-window-option synchronize-panes
 
-# explicitly disable mouse control
-# setw -g mode-mouse off
-# set -g mouse-select-pane off
-# set -g mouse-resize-pane off
-# set -g mouse-select-window off
-
 # mouse control for tmux v2.1
 set -g mouse on
 
 # ---------------------
 # Copy & Paste
 # ---------------------
-# provide access to the clipboard for pbpaste, pbcopy
-set -g default-command "reattach-to-user-namespace -l $SHELL; cd ."
-# set-option -g default-command "reattach-to-user-namespace -l zsh"
-set-window-option -g automatic-rename on
-
 # use vim keybindings in copy mode
 setw -g mode-keys vi
 
 # setup 'v' to begin selection as in Vim
-bind-key -T copy-mode-vi v send-keys -X begin-selection
-bind-key -T copy-mode-vi y send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
+bind-key -T copy-mode-vi 'v' send-keys -X begin-selection
+bind-key -T copy-mode-vi 'y' send-keys -X copy-selection-and-cancel
+bind-key p paste-buffer
 
-# update default binding of 'Enter' to also use copy-pipe
-unbind -T copy-mode-vi Enter
-bind-key -T copy-mode-vi Enter send-keys -X copy-pipe "reattach-to-user-namespace pbcopy"
-
-bind y run 'tmux save-buffer - | reattach-to-user-namespace pbcopy '
-bind C-y run 'tmux save-buffer - | reattach-to-user-namespace pbcopy '
+# handle macOS
+if-shell 'test "$(uname)" = "Darwin"' 'source ~/.tmux-macos.conf'
 
 # Save entire tmux history to a file - file will be on machine where tmux is
 # running
 bind-key * command-prompt -p 'save history to filename:' -I '~/tmux.history' 'capture-pane -S -32768 ; save-buffer %1 ; delete-buffer'
-
-# -----------------------
-# Multistart panes
-# ----------------------
-bind-key P run-shell 'tmux-multistart as'
-bind-key A run-shell 'tmux-multistart alpha'
-bind-key B run-shell 'tmux-multistart beta'
-bind-key W run-shell 'tmux-multistart web'
-bind-key D run-shell 'tmux-multistart dev'
-bind-key T run-shell 'tmux-multistart txhub'
-
-bind-key C command-prompt -p "machine(s)/group: " "run-shell 'tmux-multistart %1'"
 
 # ----------------------
 # set some pretty colors
@@ -146,17 +116,12 @@ set-window-option -g window-status-current-fg brightred #orange
 set-window-option -g window-status-current-bg colour236
 set-window-option -g window-status-current-attr bright
 
-# show host name and IP address on left side of status bar
+# Status Bar
+# left: host, load averages, prefix key indicator
+# right: session name, window & pane number, date & time
 set -g status-left-length 85
-#set -g status-left "#[fg=green]: #h : #[fg=brightblue]#(dig +short myip.opendns.com @resolver1.opendns.com) #[fg=yellow]#(ifconfig en0 | grep 'inet ' | awk '{print \"en0 \" $2}') #(ifconfig en1 | grep 'inet ' | awk '{print \"en1 \" $2}') #(ifconfig en3 | grep 'inet ' | awk '{print \"en3 \" $2}') #[fg=red]#(ifconfig tun0 | grep 'inet ' | awk '{print \"vpn \" $2}') #[fg=green]#(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk -F': ' '/ SSID/{print $2}') "
-# set -g status-left "#[fg=green]: #h : #[fg=brightblue]#(curl icanhazip.com) #[fg=yellow]#(ifconfig en0 | grep 'inet ' | awk '{print \"en0 \" $2}') #(ifconfig en1 | grep 'inet ' | awk '{print \"en1 \" $2}') #(ifconfig en3 | grep 'inet ' | awk '{print \"en3 \" $2}') #[fg=red]#(ifconfig tun0 | grep 'inet ' | awk '{print \"vpn \" $2}') #[fg=green]#(/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk -F': ' '/ SSID/{print $2}') "
-
-# Show host, load averages, and an indicator for the prefix key
 set -g status-left "#[fg=green]: #h : #[fg=brightblue]#(uptime | rev | cut -d ' ' -f 1-3 | rev) #{?client_prefix,#[fg=colour2]^A,} "
 
-# show session name, window & pane number, date and time on right side of
-# status bar
 set -g status-right-length 80
-#set -g status-right "#[fg=cyan]#{=15:pane_title} : #[fg=blue]#S #I:#P #[fg=yellow]: %d %b %Y #[fg=green]: %l:%M %p : #(date -u | awk '{print $4}') :"
 set -g status-right "#[fg=blue]#S #I:#P #[fg=yellow]: %d %b %Y #[fg=green]: %l:%M %p : #(date -u | awk '{print $4}') :"
 


### PR DESCRIPTION
Segregated macOS specific copy/paste configuration to its own file,
which is only sourced when on a Mac. This eliminates the need for two
nearly identical but slightly different tmux configurations.

Cleaned out some cruft (commented out settings) and tighted up file.