### PR TITLE
Fixed header order

### DIFF
--- a/mutt/headers
+++ b/mutt/headers
@@ -7,21 +7,24 @@
 ignore *
 
 # Then un-ignore the ones I want to see
-unignore From:
-unignore To:
-unignore Reply-To:
-unignore Mail-Followup-To:
-unignore Subject:
-unignore Date:
-unignore Organization:
-unignore Newsgroups:
-unignore CC:
-unignore BCC:
-unignore X-Mailer:
-unignore User-Agent:
-unignore X-Virus-Status:
-unignore X-Spam-Status:
-unignore X-Spam-Flag:
+unignore From
+unignore To
+unignore Reply-To
+unignore Mail-Followup-To
+unignore Subject
+unignore Date
+unignore Organization
+unignore Newsgroups
+unignore CC
+unignore BCC
+unignore X-Mailer
+unignore User-Agent
+# unignore X-Virus-Status
+# unignore X-Spam-Status
+# unignore X-Spam-Flag
+unignore X-Spam-Score
+unignore X-PGP-Key
 
 # Now order the visable header lines
-hdr_order From: Subject: To: CC: BCC: Reply-To: Mail-Followup-To: Date: Organization: User-Agent: X-Virus-Status: X-Spam-Status: X-Spam-Flag:
+unhdr_order *
+hdr_order From Subject To CC BCC Reply-To Mail-Followup-To Date Organization User-Agent X-Spame-Score X-PGP-Key


### PR DESCRIPTION
Needed `unhdr_order` to remove system defined header order
Removed Unnecessary spam headers - can see them using `h` toggle
Added PGP Key header